### PR TITLE
Feature/deployments

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.0.x
 
@@ -29,7 +29,7 @@ jobs:
         run: dotnet publish -c Release -r win-x64 --artifacts-path ./output
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: build-outputs
           path: ./output/publish

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -1,0 +1,124 @@
+name: Reusable Deploy
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+        description: 'Environment name (preprod or prod)'
+      aws-region:
+        required: false
+        type: string
+        default: 'eu-west-2'
+    secrets:
+      AWS_ROLE_ARN:
+        required: true
+      AWS_SECRETS_ARN:
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  load-services:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.load.outputs.services }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      
+      - name: Load service mappings
+        id: load
+        run: |
+          services=$(jq -c '.services' infra/services.json)
+          echo "services=${services}" >> $GITHUB_OUTPUT
+          echo "Loaded services:"
+          echo "${services}" | jq '.'
+
+  deploy:
+    needs: load-services
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.load-services.outputs.services) }}
+      fail-fast: false
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run tests
+        run: dotnet test --configuration Release
+
+      - name: Build and Publish Image
+        id: build-image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.environment }}/${{ matrix.service.name }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          PROJECT_PATH="src/${{ matrix.service.project }}"
+          
+          if [ ! -f "$PROJECT_PATH" ]; then
+            echo "Project not found: $PROJECT_PATH - Skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "Building and publishing: $PROJECT_PATH"
+          
+          dotnet publish "$PROJECT_PATH" \
+            --configuration Release \
+            --target:PublishContainer \
+            --property:ContainerRegistry=$REGISTRY \
+            --property:ContainerRepository=$REPOSITORY \
+            --property:ContainerImageTag=$IMAGE_TAG
+          
+          IMAGE="${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
+          echo "IMAGE=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "Published image: ${IMAGE}"
+
+      - name: Render ECS task definition
+        if: steps.build-image.outputs.skip != 'true'
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1.8.1
+        with:
+          task-definition: ${{ matrix.service.taskDef }}
+          container-name: ${{ matrix.service.container }}
+          image: ${{ steps.build-image.outputs.image }}
+          environment-variables: |
+            DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}
+          secrets: |
+            AzureAd__ClientId=${{ secrets.AWS_SECRETS_ARN }}:Client_ID::
+            AzureAd__ClientSecret=${{ secrets.AWS_SECRETS_ARN }}:Client_Secret::
+            API__BaseUrl=${{ secrets.AWS_SECRETS_ARN }}:API_Base_URL::
+
+      - name: Deploy ECS service
+        if: steps.build-image.outputs.skip != 'true'
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
+          service: ${{ matrix.service.name }}-service-1
+          cluster: ${{ matrix.service.name }}-cluster
+          wait-for-service-stability: true

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -209,6 +209,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.render-task-def.outputs.task-definition }}
-          service: ${{ matrix.service.name }}-service-1
-          cluster: ${{ matrix.service.name }}-cluster
+          service: DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-${{ matrix.service.name }}-service
+          cluster: DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-Cluster
           wait-for-service-stability: true

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -76,7 +76,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Fetch IAM Role ARNs from Secrets Manager
+      - name: Fetch IAM Role ARNs and EFS config from Secrets Manager
         id: fetch-roles
         run: |
           SECRET_JSON=$(aws secretsmanager get-secret-value \
@@ -86,13 +86,19 @@ jobs:
           
           TASK_ROLE=$(echo "$SECRET_JSON" | jq -r '.Task_Role_ARN')
           EXEC_ROLE=$(echo "$SECRET_JSON" | jq -r '.Execution_Role_ARN')
+          EFS_FS_ID=$(echo "$SECRET_JSON" | jq -r '.EFS_File_System_ID')
+          EFS_AP_ID=$(echo "$SECRET_JSON" | jq -r '.EFS_Access_Point_ID')
           
           # Mask secrets in logs
           echo "::add-mask::$TASK_ROLE"
           echo "::add-mask::$EXEC_ROLE"
+          echo "::add-mask::$EFS_FS_ID"
+          echo "::add-mask::$EFS_AP_ID"
           
           echo "task-role=${TASK_ROLE}" >> $GITHUB_OUTPUT
           echo "exec-role=${EXEC_ROLE}" >> $GITHUB_OUTPUT
+          echo "efs-fs-id=${EFS_FS_ID}" >> $GITHUB_OUTPUT
+          echo "efs-ap-id=${EFS_AP_ID}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -173,6 +179,14 @@ jobs:
           echo "secrets<<EOF" >> $GITHUB_OUTPUT
           echo "$SECRETS_STRING" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Replace EFS placeholders in task definition
+        if: steps.build-image.outputs.skip != 'true'
+        run: |
+          sed -i.bak \
+            -e 's/EFS_FILE_SYSTEM_ID/${{ steps.fetch-roles.outputs.efs-fs-id }}/g' \
+            -e 's/EFS_ACCESS_POINT_ID/${{ steps.fetch-roles.outputs.efs-ap-id }}/g' \
+            ${{ matrix.service.taskDef }}
 
       - name: Render ECS task definition
         if: steps.build-image.outputs.skip != 'true'

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -16,6 +16,20 @@ on:
         required: true
       AWS_SECRETS_ARN:
         required: true
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: choice
+        description: 'Environment to deploy to'
+        options:
+          - preprod
+          - prod
+      aws-region:
+        required: false
+        type: string
+        default: 'eu-west-2'
+        description: 'AWS region'
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -131,6 +131,49 @@ jobs:
           echo "skip=false" >> $GITHUB_OUTPUT
           echo "Published image: ${IMAGE}"
 
+      - name: Build secrets list for service
+        id: build-secrets
+        run: |
+          # Get the secrets array for this service from services.json
+          SECRETS_JSON='${{ toJson(matrix.service.secrets) }}'
+          
+          # Build the secrets string dynamically
+          SECRETS_STRING=""
+          
+          # Map of secret keys to their connection string names
+          declare -A SECRET_MAP=(
+            ["API_Base_URL"]="API__BaseUrl"
+            ["Authentication_ApiKey"]="Authentication__ApiKey"
+            ["S3_BucketName"]="AWS__S3__BucketName"
+            ["Client_ID"]="AzureAd__ClientId"
+            ["Client_Secret"]="AzureAd__ClientSecret"
+            ["AuditDb"]="ConnectionStrings__AuditDb"
+            ["ClusterDb"]="ConnectionStrings__ClusterDb"
+            ["DeliusRunningPictureDb"]="ConnectionStrings__DeliusRunningPictureDb"
+            ["DeliusStagingDb"]="ConnectionStrings__DeliusStagingDb"
+            ["MatchingDb"]="ConnectionStrings__MatchingDb"
+            ["OfflocRunningPictureDb"]="ConnectionStrings__OfflocRunningPictureDb"
+            ["OfflocStagingDb"]="ConnectionStrings__OfflocStagingDb"
+            ["CatsRabbitMQ"]="ConnectionStrings__CatsRabbitMQ"
+            ["RabbitMQ"]="ConnectionStrings__RabbitMQ"
+            ["DMSFilesBasePath"]="DMSFilesBasePath"
+            ["Sentry_Dsn"]="Sentry_Dsn"
+          )
+          
+          # Parse JSON array and build secrets string
+          for secret in $(echo "$SECRETS_JSON" | jq -r '.[]'); do
+            env_var_name="${SECRET_MAP[$secret]}"
+            if [ -n "$env_var_name" ]; then
+              SECRETS_STRING+="${env_var_name}=\${{ secrets.AWS_SECRETS_ARN }}:${secret}::"$'\n'
+            fi
+          done
+          
+          # Remove trailing newline and save
+          SECRETS_STRING=$(echo "$SECRETS_STRING" | sed '/^$/d')
+          echo "secrets<<EOF" >> $GITHUB_OUTPUT
+          echo "$SECRETS_STRING" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Render ECS task definition
         if: steps.build-image.outputs.skip != 'true'
         id: render-task-def
@@ -143,23 +186,7 @@ jobs:
           execution-role-arn: ${{ steps.fetch-roles.outputs.exec-role }}
           environment-variables: |
             DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}
-          secrets: |
-            API__BaseUrl=${{ secrets.AWS_SECRETS_ARN }}:API_Base_URL::
-            Authentication__ApiKey=${{ secrets.AWS_SECRETS_ARN }}:Authentication_ApiKey::
-            AWS__S3__BucketName=${{ secrets.AWS_SECRETS_ARN }}:S3_BucketName::
-            AzureAd__ClientId=${{ secrets.AWS_SECRETS_ARN }}:Client_ID::
-            AzureAd__ClientSecret=${{ secrets.AWS_SECRETS_ARN }}:Client_Secret::
-            ConnectionStrings__AuditDb=${{ secrets.AWS_SECRETS_ARN }}:AuditDb::
-            ConnectionStrings__ClusterDb=${{ secrets.AWS_SECRETS_ARN }}:ClusterDb::
-            ConnectionStrings__DeliusRunningPictureDb=${{ secrets.AWS_SECRETS_ARN }}:DeliusRunningPictureDb::
-            ConnectionStrings__DeliusStagingDb=${{ secrets.AWS_SECRETS_ARN }}:DeliusStagingDb::
-            ConnectionStrings__MatchingDb=${{ secrets.AWS_SECRETS_ARN }}:MatchingDb::
-            ConnectionStrings__OfflocRunningPictureDb=${{ secrets.AWS_SECRETS_ARN }}:OfflocRunningPictureDb::
-            ConnectionStrings__OfflocStagingDb=${{ secrets.AWS_SECRETS_ARN }}:OfflocStagingDb::
-            ConnectionStrings__CatsRabbitMQ=${{ secrets.AWS_SECRETS_ARN }}:CatsRabbitMQ::
-            ConnectionStrings__RabbitMQ=${{ secrets.AWS_SECRETS_ARN }}:RabbitMQ::
-            DMSFilesBasePath=${{ secrets.AWS_SECRETS_ARN }}:DMSFilesBasePath::
-            Sentry_Dsn=${{ secrets.AWS_SECRETS_ARN }}:Sentry_Dsn::
+          secrets: ${{ steps.build-secrets.outputs.secrets }}
 
             
 

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -16,6 +16,10 @@ on:
         required: true
       AWS_SECRETS_ARN:
         required: true
+      AWS_TASK_ROLE_ARN:
+        required: true
+      AWS_EXECUTION_ROLE_ARN:
+        required: true
 
 permissions:
   id-token: write
@@ -107,12 +111,29 @@ jobs:
           task-definition: ${{ matrix.service.taskDef }}
           container-name: ${{ matrix.service.container }}
           image: ${{ steps.build-image.outputs.image }}
+          task-role-arn: ${{ secrets.AWS_TASK_ROLE_ARN }}
+          execution-role-arn: ${{ secrets.AWS_EXECUTION_ROLE_ARN }}
           environment-variables: |
             DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}
           secrets: |
+            API__BaseUrl=${{ secrets.AWS_SECRETS_ARN }}:API_Base_URL::
+            Authentication__ApiKey=${{ secrets.AWS_SECRETS_ARN }}:Authentication_ApiKey::
+            AWS__S3__BucketName=${{ secrets.AWS_SECRETS_ARN }}:S3_BucketName::
             AzureAd__ClientId=${{ secrets.AWS_SECRETS_ARN }}:Client_ID::
             AzureAd__ClientSecret=${{ secrets.AWS_SECRETS_ARN }}:Client_Secret::
-            API__BaseUrl=${{ secrets.AWS_SECRETS_ARN }}:API_Base_URL::
+            ConnectionStrings__AuditDb=${{ secrets.AWS_SECRETS_ARN }}:AuditDb::
+            ConnectionStrings__ClusterDb=${{ secrets.AWS_SECRETS_ARN }}:ClusterDb::
+            ConnectionStrings__DeliusRunningPictureDb=${{ secrets.AWS_SECRETS_ARN }}:DeliusRunningPictureDb::
+            ConnectionStrings__DeliusStagingDb=${{ secrets.AWS_SECRETS_ARN }}:DeliusStagingDb::
+            ConnectionStrings__MatchingDb=${{ secrets.AWS_SECRETS_ARN }}:MatchingDb::
+            ConnectionStrings__OfflocRunningPictureDb=${{ secrets.AWS_SECRETS_ARN }}:OfflocRunningPictureDb::
+            ConnectionStrings__OfflocStagingDb=${{ secrets.AWS_SECRETS_ARN }}:OfflocStagingDb::
+            ConnectionStrings__CatsRabbitMQ=${{ secrets.AWS_SECRETS_ARN }}:CatsRabbitMQ::
+            ConnectionStrings__RabbitMQ=${{ secrets.AWS_SECRETS_ARN }}:RabbitMQ::
+            DMSFilesBasePath=${{ secrets.AWS_SECRETS_ARN }}:DMSFilesBasePath::
+            Sentry_Dsn=${{ secrets.AWS_SECRETS_ARN }}:Sentry_Dsn::
+
+            
 
       - name: Deploy ECS service
         if: steps.build-image.outputs.skip != 'true'

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Debug logging 
+      - name: Print debug info
+        run: |
+          echo "Deploying to environment: ${{ inputs.environment }}"
+          echo "Deploying service: ${{ matrix.service.name }}"
+          echo "Project path: src/${{ matrix.service.project }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "Repository: ${{ github.repository }}"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -112,8 +112,8 @@ jobs:
         id: build-image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: ${{ inputs.environment }}/${{ matrix.service.name }}
-          IMAGE_TAG: ${{ github.sha }}
+          REPOSITORY: dms-${{ inputs.environment }}-apps
+          IMAGE_TAG: ${{ matrix.service.name }}-${{ github.sha }}
         run: |
           PROJECT_PATH="src/${{ matrix.service.project }}"
           

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -81,6 +81,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
+      # Debug logging
+      - name: Confirm AWS credentials
+        run: aws sts get-caller-identity
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -16,10 +16,6 @@ on:
         required: true
       AWS_SECRETS_ARN:
         required: true
-      AWS_TASK_ROLE_ARN:
-        required: true
-      AWS_EXECUTION_ROLE_ARN:
-        required: true
 
 permissions:
   id-token: write
@@ -66,6 +62,24 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Fetch IAM Role ARNs from Secrets Manager
+        id: fetch-roles
+        run: |
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id ${{ secrets.AWS_SECRETS_ARN }} \
+            --query 'SecretString' \
+            --output text)
+          
+          TASK_ROLE=$(echo "$SECRET_JSON" | jq -r '.Task_Role_ARN')
+          EXEC_ROLE=$(echo "$SECRET_JSON" | jq -r '.Execution_Role_ARN')
+          
+          # Mask secrets in logs
+          echo "::add-mask::$TASK_ROLE"
+          echo "::add-mask::$EXEC_ROLE"
+          
+          echo "task-role=${TASK_ROLE}" >> $GITHUB_OUTPUT
+          echo "exec-role=${EXEC_ROLE}" >> $GITHUB_OUTPUT
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -111,8 +125,8 @@ jobs:
           task-definition: ${{ matrix.service.taskDef }}
           container-name: ${{ matrix.service.container }}
           image: ${{ steps.build-image.outputs.image }}
-          task-role-arn: ${{ secrets.AWS_TASK_ROLE_ARN }}
-          execution-role-arn: ${{ secrets.AWS_EXECUTION_ROLE_ARN }}
+          task-role-arn: ${{ steps.fetch-roles.outputs.task-role }}
+          execution-role-arn: ${{ steps.fetch-roles.outputs.exec-role }}
           environment-variables: |
             DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}
           secrets: |

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -197,3 +197,19 @@ jobs:
           echo "$UPDATED_TASK_DEF" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Render ECS task definition with secrets
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1.8.1
+        with:
+          task-definition: ${{ steps.inject-roles.outputs.updated_task_def }}
+          container-name: ${{ matrix.service.container }}
+          # image: ${{ steps.build-image.outputs.IMAGE }}
+          environment-variables: |
+            DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}
+          secrets: ${{ steps.build-secrets.outputs.secrets }}
+
+      - name: Preview rendered ECS task definition
+        run: |
+          echo "Rendered task definition:"
+          echo "${{ steps.render-task-def.outputs.task-definition }}" | jq '.'

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -190,19 +190,20 @@ jobs:
             '.taskRoleArn = $task_role | .executionRoleArn = $exec_role' \
             "$TASK_DEF_PATH")
 
-          echo "Updated task definition:"
-          echo "$UPDATED_TASK_DEF" | jq '.'
+          UPDATED_TASK_DEF_FILE="rendered-task-def.json"
+          echo "$UPDATED_TASK_DEF" > "$UPDATED_TASK_DEF_FILE"
 
-          echo "updated_task_def<<EOF" >> $GITHUB_OUTPUT
-          echo "$UPDATED_TASK_DEF" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Updated task definition:"
+          cat "$UPDATED_TASK_DEF_FILE" | jq '.'
+
+          echo "updated_task_def_file=$UPDATED_TASK_DEF_FILE" >> $GITHUB_OUTPUT
           echo "skip=false" >> $GITHUB_OUTPUT
 
       - name: Render ECS task definition with secrets
         id: render-task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1.8.1
         with:
-          task-definition: ${{ steps.inject-roles.outputs.updated_task_def }}
+          task-definition: ${{ steps.inject-roles.outputs.updated_task_def_file }}
           container-name: ${{ matrix.service.container }}
           image: amazon/amazon-ecs-sample:latest
           # image: ${{ steps.build-image.outputs.IMAGE }}

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -66,169 +66,67 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      # Debug logging 
-      - name: Print debug info
-        run: |
-          echo "Deploying to environment: ${{ inputs.environment }}"
-          echo "Deploying service: ${{ matrix.service.name }}"
-          echo "Project path: src/${{ matrix.service.project }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Repository: ${{ github.repository }}"
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
-      # Debug logging
-      - name: Confirm AWS credentials
-        run: aws sts get-caller-identity
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Fetch IAM Role ARNs and EFS config from Secrets Manager
-        id: fetch-roles
-        run: |
-          SECRET_JSON=$(aws secretsmanager get-secret-value \
-            --secret-id ${{ secrets.AWS_SECRETS_ARN }} \
-            --query 'SecretString' \
-            --output text)
-          
-          TASK_ROLE=$(echo "$SECRET_JSON" | jq -r '.Task_Role_ARN')
-          EXEC_ROLE=$(echo "$SECRET_JSON" | jq -r '.Execution_Role_ARN')
-          EFS_FS_ID=$(echo "$SECRET_JSON" | jq -r '.EFS_File_System_ID')
-          EFS_AP_ID=$(echo "$SECRET_JSON" | jq -r '.EFS_Access_Point_ID')
-          
-          # Mask secrets in logs
-          echo "::add-mask::$TASK_ROLE"
-          echo "::add-mask::$EXEC_ROLE"
-          echo "::add-mask::$EFS_FS_ID"
-          echo "::add-mask::$EFS_AP_ID"
-          
-          echo "task-role=${TASK_ROLE}" >> $GITHUB_OUTPUT
-          echo "exec-role=${EXEC_ROLE}" >> $GITHUB_OUTPUT
-          echo "efs-fs-id=${EFS_FS_ID}" >> $GITHUB_OUTPUT
-          echo "efs-ap-id=${EFS_AP_ID}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
-      - name: Run tests
-        run: dotnet test --configuration Release
+      # - name: Run tests
+      #   run: dotnet test --configuration Release
 
-      - name: Build and Publish Image
-        id: build-image
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: dms-${{ inputs.environment }}-apps
-          IMAGE_TAG: ${{ matrix.service.name }}-${{ github.sha }}
+      # - name: Build and Publish Image
+      #   id: build-image
+      #   env:
+      #     REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      #     REPOSITORY: dms-${{ inputs.environment }}-apps
+      #     IMAGE_TAG: ${{ matrix.service.name }}-${{ github.sha }}
+      #   run: |
+      #     PROJECT_PATH="src/${{ matrix.service.project }}"
+          
+      #     if [ ! -f "$PROJECT_PATH" ]; then
+      #       echo "Project not found: $PROJECT_PATH - Skipping"
+      #       echo "skip=true" >> $GITHUB_OUTPUT
+      #       exit 0
+      #     fi
+          
+      #     echo "Building and publishing: $PROJECT_PATH"
+          
+      #     dotnet publish "$PROJECT_PATH" \
+      #       --configuration Release \
+      #       --target:PublishContainer \
+      #       --property:ContainerRegistry=$REGISTRY \
+      #       --property:ContainerRepository=$REPOSITORY \
+      #       --property:ContainerImageTag=$IMAGE_TAG
+          
+      #     IMAGE="${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
+      #     echo "IMAGE=${IMAGE}" >> $GITHUB_OUTPUT
+      #     echo "skip=false" >> $GITHUB_OUTPUT
+      #     echo "Published image: ${IMAGE}"
+
+      - name: Testing workflow steps
+        run: echo "The testing / deployment of the image have been skipped for this demo, but the workflow is correctly iterating over the services and would deploy the built image to ECS if those steps were uncommented."
+      
+      - name : Fetch required secrets
+        id: fetch-secrets
         run: |
-          PROJECT_PATH="src/${{ matrix.service.project }}"
-          
-          if [ ! -f "$PROJECT_PATH" ]; then
-            echo "Project not found: $PROJECT_PATH - Skipping"
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          echo "Building and publishing: $PROJECT_PATH"
-          
-          dotnet publish "$PROJECT_PATH" \
-            --configuration Release \
-            --target:PublishContainer \
-            --property:ContainerRegistry=$REGISTRY \
-            --property:ContainerRepository=$REPOSITORY \
-            --property:ContainerImageTag=$IMAGE_TAG
-          
-          IMAGE="${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
-          echo "IMAGE=${IMAGE}" >> $GITHUB_OUTPUT
-          echo "skip=false" >> $GITHUB_OUTPUT
-          echo "Published image: ${IMAGE}"
-
-      - name: Build secrets list for service
-        id: build-secrets
-        run: |
-          # Get the secrets array for this service from services.json
-          SECRETS_JSON='${{ toJson(matrix.service.secrets) }}'
-          
-          # Build the secrets string dynamically
-          SECRETS_STRING=""
-          
-          # Map of secret keys to their connection string names
-          declare -A SECRET_MAP=(
-            ["API_Base_URL"]="API__BaseUrl"
-            ["Authentication_ApiKey"]="Authentication__ApiKey"
-            ["S3_BucketName"]="AWS__S3__BucketName"
-            ["Client_ID"]="AzureAd__ClientId"
-            ["Client_Secret"]="AzureAd__ClientSecret"
-            ["AuditDb"]="ConnectionStrings__AuditDb"
-            ["ClusterDb"]="ConnectionStrings__ClusterDb"
-            ["DeliusRunningPictureDb"]="ConnectionStrings__DeliusRunningPictureDb"
-            ["DeliusStagingDb"]="ConnectionStrings__DeliusStagingDb"
-            ["MatchingDb"]="ConnectionStrings__MatchingDb"
-            ["OfflocRunningPictureDb"]="ConnectionStrings__OfflocRunningPictureDb"
-            ["OfflocStagingDb"]="ConnectionStrings__OfflocStagingDb"
-            ["CatsRabbitMQ"]="ConnectionStrings__CatsRabbitMQ"
-            ["RabbitMQ"]="ConnectionStrings__RabbitMQ"
-            ["DMSFilesBasePath"]="DMSFilesBasePath"
-            ["Sentry_Dsn"]="Sentry_Dsn"
-          )
-          
-          # Parse JSON array and build secrets string
-          for secret in $(echo "$SECRETS_JSON" | jq -r '.[]'); do
-            env_var_name="${SECRET_MAP[$secret]}"
-            if [ -n "$env_var_name" ]; then
-              SECRETS_STRING+="${env_var_name}=\${{ secrets.AWS_SECRETS_ARN }}:${secret}::"$'\n'
-            fi
-          done
-          
-          # Remove trailing newline and save
-          SECRETS_STRING=$(echo "$SECRETS_STRING" | sed '/^$/d')
-          echo "secrets<<EOF" >> $GITHUB_OUTPUT
-          echo "$SECRETS_STRING" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Replace EFS placeholders in task definition
-        if: steps.build-image.outputs.skip != 'true'
-        run: |
-          sed -i.bak \
-            -e 's/EFS_FILE_SYSTEM_ID/${{ steps.fetch-roles.outputs.efs-fs-id }}/g' \
-            -e 's/EFS_ACCESS_POINT_ID/${{ steps.fetch-roles.outputs.efs-ap-id }}/g' \
-            ${{ matrix.service.taskDef }}
-
-      - name: Inject IAM roles into task definition
-        if: steps.build-image.outputs.skip != 'true'
-        run: |
-          jq --arg taskRole "${{ steps.fetch-roles.outputs.task-role }}" \
-             --arg execRole "${{ steps.fetch-roles.outputs.exec-role }}" \
-             '.taskRoleArn = $taskRole | .executionRoleArn = $execRole' \
-             ${{ matrix.service.taskDef }} > task-def-updated.json
-          mv task-def-updated.json ${{ matrix.service.taskDef }}
-
-      - name: Render ECS task definition
-        if: steps.build-image.outputs.skip != 'true'
-        id: render-task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1.8.1
-        with:
-          task-definition: ${{ matrix.service.taskDef }}
-          container-name: ${{ matrix.service.container }}
-          image: ${{ steps.build-image.outputs.image }}
-          environment-variables: |
-            DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}
-          secrets: ${{ steps.build-secrets.outputs.secrets }}
-
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+              --secret-id ${{ secrets.AWS_SECRETS_ARN }} \
+              --query 'SecretString' \
+              --output text)
             
+            TASK_ROLE=$(echo "$SECRET_JSON" | jq -r '.Task_Role_ARN')
+            EXEC_ROLE=$(echo "$SECRET_JSON" | jq -r '.Execution_Role_ARN')
 
-      - name: Deploy ECS service
-        if: steps.build-image.outputs.skip != 'true'
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-        with:
-          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
-          service: DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-${{ matrix.service.name }}-service
-          cluster: DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-Cluster
-          wait-for-service-stability: true
+          echo "Task/Exec role arns (not masked as they are not sensitive):"
+          echo "TASK_ROLE=${TASK_ROLE}" >> $GITHUB_OUTPUT
+          echo "EXEC_ROLE=${EXEC_ROLE}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -157,7 +157,7 @@ jobs:
           )
 
           SECRETS_LIST=""
-          for secret in $(echo "$SECRETS_JSON" | jq -r '.[]'); do
+          echo "$SECRETS_JSON" | jq -r '.[]' | while read -r secret; do
             ENV_NAME="${SECRET_MAP[$secret]}"
             if [ -n "$ENV_NAME" ]; then
               SECRETS_LIST+="${ENV_NAME}=${SECRET_ARN}:${secret}::"$'\n'

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Inject roles in task definition
         id: inject-roles
         run: |
-          TASK_DEF_PATH=${{ matrix.service.task_def }}
+          TASK_DEF_PATH="${{ matrix.service.taskdef }}"
           
           if [ ! -f "$TASK_DEF_PATH" ]; then
             echo "Task definition not found: $TASK_DEF_PATH - Skipping"

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -214,4 +214,4 @@ jobs:
       - name: Preview rendered ECS task definition
         run: |
           echo "Rendered task definition:"
-          echo "${{ steps.render-task-def.outputs.task-definition }}" | jq '.'
+          cat "${{ steps.inject-roles.outputs.updated_task_def_file }}" | jq '.'

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -116,17 +116,20 @@ jobs:
       - name: Testing workflow steps
         run: echo "The testing / deployment of the image have been skipped for this demo, but the workflow is correctly iterating over the services and would deploy the built image to ECS if those steps were uncommented."
       
-      - name : Fetch required secrets
+      - name: Fetch required secrets
         id: fetch-secrets
         run: |
           SECRET_JSON=$(aws secretsmanager get-secret-value \
-              --secret-id ${{ secrets.AWS_SECRETS_ARN }} \
-              --query 'SecretString' \
-              --output text)
-            
-            TASK_ROLE=$(echo "$SECRET_JSON" | jq -r '.Task_Role_ARN')
-            EXEC_ROLE=$(echo "$SECRET_JSON" | jq -r '.Execution_Role_ARN')
+            --secret-id ${{ secrets.AWS_SECRETS_ARN }} \
+            --query 'SecretString' \
+            --output text)
 
-          echo "Task/Exec role arns (not masked as they are not sensitive):"
-          echo "TASK_ROLE=${TASK_ROLE}" >> $GITHUB_OUTPUT
-          echo "EXEC_ROLE=${EXEC_ROLE}" >> $GITHUB_OUTPUT
+          TASK_ROLE=$(echo "$SECRET_JSON" | jq -r '.Task_Role_ARN')
+          EXEC_ROLE=$(echo "$SECRET_JSON" | jq -r '.Execution_Role_ARN')
+
+          echo "Task/Exec role ARNs:"
+          echo "Task Role: $TASK_ROLE"
+          echo "Exec Role: $EXEC_ROLE"
+
+          echo "task_role=$TASK_ROLE" >> $GITHUB_OUTPUT
+          echo "exec_role=$EXEC_ROLE" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -81,37 +81,37 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      # - name: Run tests
-      #   run: dotnet test --configuration Release
+      - name: Run tests
+        run: dotnet test --configuration Release
 
-      # - name: Build and Publish Image
-      #   id: build-image
-      #   env:
-      #     REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-      #     REPOSITORY: dms-${{ inputs.environment }}-apps
-      #     IMAGE_TAG: ${{ matrix.service.name }}-${{ github.sha }}
-      #   run: |
-      #     PROJECT_PATH="src/${{ matrix.service.project }}"
+      - name: Build and Publish Image
+        id: build-image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: dms-${{ inputs.environment }}-apps
+          IMAGE_TAG: ${{ matrix.service.name }}-${{ github.sha }}
+        run: |
+          PROJECT_PATH="src/${{ matrix.service.project }}"
           
-      #     if [ ! -f "$PROJECT_PATH" ]; then
-      #       echo "Project not found: $PROJECT_PATH - Skipping"
-      #       echo "skip=true" >> $GITHUB_OUTPUT
-      #       exit 0
-      #     fi
+          if [ ! -f "$PROJECT_PATH" ]; then
+            echo "Project not found: $PROJECT_PATH - Skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           
-      #     echo "Building and publishing: $PROJECT_PATH"
+          echo "Building and publishing: $PROJECT_PATH"
           
-      #     dotnet publish "$PROJECT_PATH" \
-      #       --configuration Release \
-      #       --target:PublishContainer \
-      #       --property:ContainerRegistry=$REGISTRY \
-      #       --property:ContainerRepository=$REPOSITORY \
-      #       --property:ContainerImageTag=$IMAGE_TAG
+          dotnet publish "$PROJECT_PATH" \
+            --configuration Release \
+            --target:PublishContainer \
+            --property:ContainerRegistry=$REGISTRY \
+            --property:ContainerRepository=$REPOSITORY \
+            --property:ContainerImageTag=$IMAGE_TAG
           
-      #     IMAGE="${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
-      #     echo "IMAGE=${IMAGE}" >> $GITHUB_OUTPUT
-      #     echo "skip=false" >> $GITHUB_OUTPUT
-      #     echo "Published image: ${IMAGE}"
+          IMAGE="${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
+          echo "IMAGE=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "Published image: ${IMAGE}"
 
       - name: Testing workflow steps
         run: echo "The testing / deployment of the image have been skipped for this demo, but the workflow is correctly iterating over the services and would deploy the built image to ECS if those steps were uncommented."
@@ -205,13 +205,16 @@ jobs:
         with:
           task-definition: ${{ steps.inject-roles.outputs.updated_task_def_file }}
           container-name: ${{ matrix.service.container }}
-          image: amazon/amazon-ecs-sample:latest
-          # image: ${{ steps.build-image.outputs.IMAGE }}
+          image: ${{ steps.build-image.outputs.IMAGE }}
           environment-variables: |
             DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}
           secrets: ${{ steps.build-secrets.outputs.secrets }}
 
-      - name: Preview rendered ECS task definition
-        run: |
-          echo "Rendered task definition:"
-          cat "${{ steps.inject-roles.outputs.updated_task_def_file }}" | jq '.'
+      - name: Deploy ECS service
+        if: steps.build-image.outputs.skip != 'true'
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
+          service: DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-${{ matrix.service.name }}-service
+          cluster: DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-Cluster
+          wait-for-service-stability: true

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -130,13 +130,13 @@ jobs:
           echo "task_role=$TASK_ROLE" >> $GITHUB_OUTPUT
           echo "exec_role=$EXEC_ROLE" >> $GITHUB_OUTPUT
 
-      - name: Build ECS secrets for service
+      - name: Build secrets list for service
         id: build-secrets
         run: |
-          SECRETS_JSON=${{ toJson(matrix.service.secrets) }}
-          SERVICE_NAME=${{ matrix.service.name }}
-          SECRET_ARN=${{ secrets.AWS_SECRETS_ARN }}
-
+          SECRETS_JSON='${{ toJson(matrix.service.secrets) }}'
+          
+          SECRETS_STRING=""
+          
           declare -A SECRET_MAP=(
             ["API_Base_URL"]="API__BaseUrl"
             ["Authentication_ApiKey"]="Authentication__ApiKey"
@@ -155,21 +155,18 @@ jobs:
             ["DMSFilesBasePath"]="DMSFilesBasePath"
             ["Sentry_Dsn"]="Sentry_Dsn"
           )
-
-          SECRETS_LIST=""
-          echo "$SECRETS_JSON" | jq -r '.[]' | while read -r secret; do
-            ENV_NAME="${SECRET_MAP[$secret]}"
-            if [ -n "$ENV_NAME" ]; then
-              SECRETS_LIST+="${ENV_NAME}=${SECRET_ARN}:${secret}::"$'\n'
+          
+          for secret in $(echo "$SECRETS_JSON" | jq -r '.[]'); do
+            env_var_name="${SECRET_MAP[$secret]}"
+            if [ -n "$env_var_name" ]; then
+              SECRETS_STRING+="${env_var_name}=\${{ secrets.AWS_SECRETS_ARN }}:${secret}::"$'\n'
             fi
           done
 
-          SECRETS_LIST=$(echo "$SECRETS_LIST" | sed '/^$/d')
-
-          echo "### DEBUG ECS SECRETS - SERVICE: $SERVICE_NAME ###"
-          echo "$SECRETS_LIST"
-          echo "### END DEBUG ###"
-
+          echo "Built secrets string:"
+          echo "$SECRETS_STRING"
+          
+          SECRETS_STRING=$(echo "$SECRETS_STRING" | sed '/^$/d')
           echo "secrets<<EOF" >> $GITHUB_OUTPUT
-          echo "$SECRETS_LIST" >> $GITHUB_OUTPUT
+          echo "$SECRETS_STRING" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -198,7 +198,7 @@ jobs:
             "$TASK_DEF_PATH"
           
           # Step 2: Inject IAM roles and set family name to match Terraform convention
-          FAMILY_NAME="DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-${{ matrix.service.name }}-task"
+          FAMILY_NAME="dms-${{ inputs.environment == 'prod' && 'prod' || 'preprod' }}-${{ matrix.service.name }}-task"
           
           UPDATED_TASK_DEF=$(jq \
             --arg task_role "${{ steps.fetch-secrets.outputs.task_role }}" \
@@ -232,6 +232,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.render-task-def.outputs.task-definition }}
-          service: DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-${{ matrix.service.name }}-service
-          cluster: DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-Cluster
+          service: dms-${{ inputs.environment == 'prod' && 'prod' || 'preprod' }}-${{ matrix.service.name }}-service
+          cluster: dms-${{ inputs.environment == 'prod' && 'prod' || 'preprod' }}-cluster
           wait-for-service-stability: true

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -133,9 +133,9 @@ jobs:
       - name: Build ECS secrets for service
         id: build-secrets
         run: |
-          SECRETS_JSON="${{ toJson(matrix.service.secrets) }}"
-          SERVICE_NAME="${{ matrix.service.name }}"
-          SECRET_ARN="${{ secrets.AWS_SECRETS_ARN }}"
+          SECRETS_JSON=${{ toJson(matrix.service.secrets) }}
+          SERVICE_NAME=${{ matrix.service.name }}
+          SECRET_ARN=${{ secrets.AWS_SECRETS_ARN }}
 
           declare -A SECRET_MAP=(
             ["API_Base_URL"]="API__BaseUrl"

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -146,6 +146,7 @@ jobs:
             ["Authentication_ApiKey"]="Authentication__ApiKey"
             ["S3_BucketName"]="AWS__S3__BucketName"
             ["Client_ID"]="AzureAd__ClientId"
+            ["API_Client_ID"]="AzureAd__ClientId"
             ["Client_Secret"]="AzureAd__ClientSecret"
             ["AuditDb"]="ConnectionStrings__AuditDb"
             ["ClusterDb"]="ConnectionStrings__ClusterDb"

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -170,3 +170,30 @@ jobs:
           echo "secrets<<EOF" >> $GITHUB_OUTPUT
           echo "$SECRETS_STRING" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Inject roles in task definition
+        id: inject-roles
+        run: |
+          TASK_DEF_PATH="${{ matrix.service.task_def }}"
+          
+          if [ ! -f "$TASK_DEF_PATH" ]; then
+            echo "Task definition not found: $TASK_DEF_PATH - Skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Injecting roles into task definition: $TASK_DEF_PATH"
+
+          UPDATED_TASK_DEF=$(jq \
+            --arg task_role "${{ steps.fetch-secrets.outputs.task_role }}" \
+            --arg exec_role "${{ steps.fetch-secrets.outputs.exec_role }}" \
+            '.taskRoleArn = $task_role | .executionRoleArn = $exec_role' \
+            "$TASK_DEF_PATH")
+
+          echo "Updated task definition:"
+          echo "$UPDATED_TASK_DEF" | jq '.'
+
+          echo "updated_task_def<<EOF" >> $GITHUB_OUTPUT
+          echo "$UPDATED_TASK_DEF" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -42,7 +42,7 @@ jobs:
       services: ${{ steps.load.outputs.services }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - name: Load service mappings
         id: load
@@ -64,20 +64,20 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.0.x
 
@@ -222,7 +222,7 @@ jobs:
 
       - name: Render ECS task definition with secrets
         id: render-task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1.8.1
+        uses: aws-actions/amazon-ecs-render-task-definition@77954e213ba1f9f9cb016b86a1d4f6fcdea0d57e # v1.8.4
         with:
           task-definition: ${{ steps.inject-roles.outputs.updated_task_def_file }}
           container-name: ${{ matrix.service.container }}
@@ -233,7 +233,7 @@ jobs:
 
       - name: Deploy ECS service
         if: steps.build-image.outputs.skip != 'true'
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@fc8fc60f3a60ffd500fcb13b209c59d221ac8c8c # v2.6.1
         with:
           task-definition: ${{ steps.render-task-def.outputs.task-definition }}
           service: dms-${{ inputs.environment == 'prod' && 'prod' || 'preprod' }}-${{ matrix.service.name }}-service

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -156,10 +156,13 @@ jobs:
             ["Sentry_Dsn"]="Sentry_Dsn"
           )
           
+          # Get the full secret ARN
+          SECRET_ARN="${{ secrets.AWS_SECRETS_ARN }}"
+          
           for secret in $(echo "$SECRETS_JSON" | jq -r '.[]'); do
             env_var_name="${SECRET_MAP[$secret]}"
             if [ -n "$env_var_name" ]; then
-              SECRETS_STRING+="${env_var_name}=\${{ secrets.AWS_SECRETS_ARN }}:${secret}::"$'\n'
+              SECRETS_STRING+="${env_var_name}=${SECRET_ARN}:${secret}::"$'\n'
             fi
           done
 
@@ -171,10 +174,10 @@ jobs:
           echo "$SECRETS_STRING" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Inject roles in task definition
+      - name: Replace EFS placeholders and inject roles in task definition
         id: inject-roles
         run: |
-          TASK_DEF_PATH="${{ matrix.service.taskdef }}"
+          TASK_DEF_PATH="${{ matrix.service.taskDef }}"
           
           if [ ! -f "$TASK_DEF_PATH" ]; then
             echo "Task definition not found: $TASK_DEF_PATH - Skipping"
@@ -182,8 +185,15 @@ jobs:
             exit 0
           fi
 
-          echo "Injecting roles into task definition: $TASK_DEF_PATH"
-
+          echo "Processing task definition: $TASK_DEF_PATH"
+          
+          # Step 1: Replace EFS placeholders
+          sed -i.bak \
+            -e 's/EFS_FILE_SYSTEM_ID/${{ steps.fetch-secrets.outputs.efs-fs-id }}/g' \
+            -e 's/EFS_ACCESS_POINT_ID/${{ steps.fetch-secrets.outputs.efs-ap-id }}/g' \
+            "$TASK_DEF_PATH"
+          
+          # Step 2: Inject IAM roles
           UPDATED_TASK_DEF=$(jq \
             --arg task_role "${{ steps.fetch-secrets.outputs.task_role }}" \
             --arg exec_role "${{ steps.fetch-secrets.outputs.exec_role }}" \

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -204,6 +204,7 @@ jobs:
         with:
           task-definition: ${{ steps.inject-roles.outputs.updated_task_def }}
           container-name: ${{ matrix.service.container }}
+          image: amazon/amazon-ecs-sample:latest
           # image: ${{ steps.build-image.outputs.IMAGE }}
           environment-variables: |
             DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -127,9 +127,49 @@ jobs:
           TASK_ROLE=$(echo "$SECRET_JSON" | jq -r '.Task_Role_ARN')
           EXEC_ROLE=$(echo "$SECRET_JSON" | jq -r '.Execution_Role_ARN')
 
-          echo "Task/Exec role ARNs:"
-          echo "Task Role: $TASK_ROLE"
-          echo "Exec Role: $EXEC_ROLE"
-
           echo "task_role=$TASK_ROLE" >> $GITHUB_OUTPUT
           echo "exec_role=$EXEC_ROLE" >> $GITHUB_OUTPUT
+
+      - name: Build ECS secrets for service
+        id: build-secrets
+        run: |
+          SECRETS_JSON="${{ toJson(matrix.service.secrets) }}"
+          SERVICE_NAME="${{ matrix.service.name }}"
+          SECRET_ARN="${{ secrets.AWS_SECRETS_ARN }}"
+
+          declare -A SECRET_MAP=(
+            ["API_Base_URL"]="API__BaseUrl"
+            ["Authentication_ApiKey"]="Authentication__ApiKey"
+            ["S3_BucketName"]="AWS__S3__BucketName"
+            ["Client_ID"]="AzureAd__ClientId"
+            ["Client_Secret"]="AzureAd__ClientSecret"
+            ["AuditDb"]="ConnectionStrings__AuditDb"
+            ["ClusterDb"]="ConnectionStrings__ClusterDb"
+            ["DeliusRunningPictureDb"]="ConnectionStrings__DeliusRunningPictureDb"
+            ["DeliusStagingDb"]="ConnectionStrings__DeliusStagingDb"
+            ["MatchingDb"]="ConnectionStrings__MatchingDb"
+            ["OfflocRunningPictureDb"]="ConnectionStrings__OfflocRunningPictureDb"
+            ["OfflocStagingDb"]="ConnectionStrings__OfflocStagingDb"
+            ["CatsRabbitMQ"]="ConnectionStrings__CatsRabbitMQ"
+            ["RabbitMQ"]="ConnectionStrings__RabbitMQ"
+            ["DMSFilesBasePath"]="DMSFilesBasePath"
+            ["Sentry_Dsn"]="Sentry_Dsn"
+          )
+
+          SECRETS_LIST=""
+          for secret in $(echo "$SECRETS_JSON" | jq -r '.[]'); do
+            ENV_NAME="${SECRET_MAP[$secret]}"
+            if [ -n "$ENV_NAME" ]; then
+              SECRETS_LIST+="${ENV_NAME}=${SECRET_ARN}:${secret}::"$'\n'
+            fi
+          done
+
+          SECRETS_LIST=$(echo "$SECRETS_LIST" | sed '/^$/d')
+
+          echo "### DEBUG ECS SECRETS - SERVICE: $SERVICE_NAME ###"
+          echo "$SECRETS_LIST"
+          echo "### END DEBUG ###"
+
+          echo "secrets<<EOF" >> $GITHUB_OUTPUT
+          echo "$SECRETS_LIST" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -201,6 +201,15 @@ jobs:
             -e 's/EFS_ACCESS_POINT_ID/${{ steps.fetch-roles.outputs.efs-ap-id }}/g' \
             ${{ matrix.service.taskDef }}
 
+      - name: Inject IAM roles into task definition
+        if: steps.build-image.outputs.skip != 'true'
+        run: |
+          jq --arg taskRole "${{ steps.fetch-roles.outputs.task-role }}" \
+             --arg execRole "${{ steps.fetch-roles.outputs.exec-role }}" \
+             '.taskRoleArn = $taskRole | .executionRoleArn = $execRole' \
+             ${{ matrix.service.taskDef }} > task-def-updated.json
+          mv task-def-updated.json ${{ matrix.service.taskDef }}
+
       - name: Render ECS task definition
         if: steps.build-image.outputs.skip != 'true'
         id: render-task-def
@@ -209,8 +218,6 @@ jobs:
           task-definition: ${{ matrix.service.taskDef }}
           container-name: ${{ matrix.service.container }}
           image: ${{ steps.build-image.outputs.image }}
-          task-role-arn: ${{ steps.fetch-roles.outputs.task-role }}
-          execution-role-arn: ${{ steps.fetch-roles.outputs.exec-role }}
           environment-variables: |
             DOTNET_ENVIRONMENT=${{ inputs.environment == 'prod' && 'Production' || 'PreProduction' }}
           secrets: ${{ steps.build-secrets.outputs.secrets }}

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -191,10 +191,13 @@ jobs:
 
           echo "Processing task definition: $TASK_DEF_PATH"
           
-          # Step 1: Replace EFS placeholders
+          # Step 1: Replace placeholders (EFS, CloudWatch)
+          LOG_GROUP_NAME="dms-${{ inputs.environment == 'prod' && 'prod' || 'preprod' }}/ecs"
+          
           sed -i.bak \
             -e 's/EFS_FILE_SYSTEM_ID/${{ steps.fetch-secrets.outputs.efs-fs-id }}/g' \
             -e 's/EFS_ACCESS_POINT_ID/${{ steps.fetch-secrets.outputs.efs-ap-id }}/g' \
+            -e "s|PLACEHOLDER|$LOG_GROUP_NAME|g" \
             "$TASK_DEF_PATH"
           
           # Step 2: Inject IAM roles and set family name to match Terraform convention

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Inject roles in task definition
         id: inject-roles
         run: |
-          TASK_DEF_PATH="${{ matrix.service.task_def }}"
+          TASK_DEF_PATH=${{ matrix.service.task_def }}
           
           if [ ! -f "$TASK_DEF_PATH" ]; then
             echo "Task definition not found: $TASK_DEF_PATH - Skipping"

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -126,9 +126,13 @@ jobs:
 
           TASK_ROLE=$(echo "$SECRET_JSON" | jq -r '.Task_Role_ARN')
           EXEC_ROLE=$(echo "$SECRET_JSON" | jq -r '.Execution_Role_ARN')
+          EFS_FS_ID=$(echo "$SECRET_JSON" | jq -r '.EFS_File_System_ID')
+          EFS_AP_ID=$(echo "$SECRET_JSON" | jq -r '.EFS_Access_Point_ID')
 
           echo "task_role=$TASK_ROLE" >> $GITHUB_OUTPUT
           echo "exec_role=$EXEC_ROLE" >> $GITHUB_OUTPUT
+          echo "efs-fs-id=$EFS_FS_ID" >> $GITHUB_OUTPUT
+          echo "efs-ap-id=$EFS_AP_ID" >> $GITHUB_OUTPUT
 
       - name: Build secrets list for service
         id: build-secrets
@@ -193,11 +197,14 @@ jobs:
             -e 's/EFS_ACCESS_POINT_ID/${{ steps.fetch-secrets.outputs.efs-ap-id }}/g' \
             "$TASK_DEF_PATH"
           
-          # Step 2: Inject IAM roles
+          # Step 2: Inject IAM roles and set family name to match Terraform convention
+          FAMILY_NAME="DMS-${{ inputs.environment == 'prod' && 'Prod' || 'PreProd' }}-${{ matrix.service.name }}-task"
+          
           UPDATED_TASK_DEF=$(jq \
             --arg task_role "${{ steps.fetch-secrets.outputs.task_role }}" \
             --arg exec_role "${{ steps.fetch-secrets.outputs.exec_role }}" \
-            '.taskRoleArn = $task_role | .executionRoleArn = $exec_role' \
+            --arg family "$FAMILY_NAME" \
+            '.taskRoleArn = $task_role | .executionRoleArn = $exec_role | .family = $family' \
             "$TASK_DEF_PATH")
 
           UPDATED_TASK_DEF_FILE="rendered-task-def.json"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_SECRETS_ARN: ${{ secrets.AWS_SECRETS_ARN }}
+      AWS_TASK_ROLE_ARN: ${{ secrets.AWS_TASK_ROLE_ARN }}
+      AWS_EXECUTION_ROLE_ARN: ${{ secrets.AWS_EXECUTION_ROLE_ARN }}
 
   deploy-prod:
     if: github.ref == 'refs/heads/main'
@@ -29,3 +31,5 @@ jobs:
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_SECRETS_ARN: ${{ secrets.AWS_SECRETS_ARN }}
+      AWS_TASK_ROLE_ARN: ${{ secrets.AWS_TASK_ROLE_ARN }}
+      AWS_EXECUTION_ROLE_ARN: ${{ secrets.AWS_EXECUTION_ROLE_ARN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,71 +6,26 @@ on:
       - main
 
 permissions:
-  id-token: write # required for OIDC authentication with AWS
+  id-token: write
+  contents: read
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
+  deploy-preprod:
+    if: github.ref == 'refs/heads/develop'
+    uses: ./.github/workflows/deploy-reusable.yml
+    with:
+      environment: preprod
+      aws-region: eu-west-2
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_SECRETS_ARN: ${{ secrets.AWS_SECRETS_ARN }}
 
-    environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
-
-    env:
-      REPOSITORY: dms_visualiser
-      IMAGE_TAG: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}-${{ github.sha }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: eu-west-2
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Run tests
-        run: dotnet test --configuration Release
-
-      - name: Build and Publish Image
-        id: build-image
-        run: |
-          dotnet publish src/Visualiser/Visualiser.csproj \
-          --configuration Release \
-          --target:PublishContainer \
-          --property:ContainerRegistry=${{ steps.login-ecr.outputs.registry }} \
-          --property:ContainerRepository=$REPOSITORY \
-          --property:ContainerImageTag=$IMAGE_TAG
-
-          IMAGE=${{ steps.login-ecr.outputs.registry }}/${REPOSITORY}:${IMAGE_TAG}
-          echo "IMAGE=${IMAGE}" >> $GITHUB_OUTPUT
-
-      - name: Render ECS task definition
-        id: render-task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1.8.1
-        with:
-          task-definition: infra/dms-visualiser-task-def.json
-          container-name: dms-visualiser-container
-          image: ${{ steps.build-image.outputs.image }}
-          environment-variables: |
-            VERY_IMPORTANT=DO_NOT_DELETE_ME
-            DOTNET_ENVIRONMENT=PreProduction
-          secrets: |
-            AzureAd__ClientId=${{ secrets.AWS_SECRETS_ARN }}:Client_ID::
-            AzureAd__ClientSecret=${{ secrets.AWS_SECRETS_ARN }}:Client_Secret::
-            API__BaseUrl=${{ secrets.AWS_SECRETS_ARN }}:API_Base_URL::
-
-      - name: Deploy ECS service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-        with:
-          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
-          service: dms-visualiser-service-1
-          cluster: dms-visualiser-cluster
+  deploy-prod:
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/deploy-reusable.yml
+    with:
+      environment: prod
+      aws-region: eu-west-2
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      AWS_SECRETS_ARN: ${{ secrets.AWS_SECRETS_ARN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: mcr.microsoft.com/dotnet/sdk:10.0
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore Dependencies (ubuntu)
         run: |
@@ -34,10 +34,10 @@ jobs:
   test-windows:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.0.x
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.0.2" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.1.0" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.0.2" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.1.0" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.1.0" />

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,165 @@
+# DMS Infrastructure - AWS Fargate
+
+This directory contains AWS Fargate ECS task definitions for the DMS (Data Management System).
+
+## Contents
+
+## Structure
+
+```
+infra/
+├── services.json              # Service deployment configuration
+├── README.md                  # This file
+└── task-definitions/          # ECS task definition files
+    ├── api-task-def.json
+    ├── blocking-task-def.json
+    └── ...
+```
+
+### Service Mappings
+`services.json` - Central configuration mapping services to projects and task definitions.
+This file is used by the CI/CD pipeline to automatically deploy all services.
+
+**Adding a new service:**
+1. Create the task definition JSON file in `task-definitions/` (e.g., `my-service-task-def.json`)
+2. Add an entry to `services.json`:
+```json
+{
+  "name": "my-service",
+  "project": "MyService/MyService.csproj",
+  "taskDef": "infra/task-definitions/my-service-task-def.json",
+  "container": "my-service-container"
+}
+```
+3. Push to `develop` or `main` - deployment is automatic!
+
+### Task Definitions
+Each service has its own ECS Fargate task definition JSON file in `task-definitions/`:
+- `api-task-def.json` - REST API service (512 CPU, 1024 MB)
+- `blocking-task-def.json` - Blocking service (512 CPU, 1024 MB)
+- `cleanup-task-def.json` - Cleanup service (256 CPU, 512 MB)
+- `delius-parser-task-def.json` - Delius data parser (512 CPU, 1024 MB)
+- `filesync-task-def.json` - File synchronization service (512 CPU, 1024 MB)
+- `import-task-def.json` - Data import service (512 CPU, 1024 MB)
+- `logging-task-def.json` - Logging aggregation (256 CPU, 512 MB)
+- `matching-engine-task-def.json` - Matching engine (1024 CPU, 2048 MB)
+- `meow-task-def.json` - Meow service (512 CPU, 1024 MB)
+- `offloc-cleaner-task-def.json` - Offloc cleaner (512 CPU, 1024 MB)
+- `offloc-parser-task-def.json` - Offloc parser (512 CPU, 1024 MB)
+- `visualiser-task-def.json` - Visualiser UI (256 CPU, 512 MB)
+
+## Prerequisites
+
+1. AWS CLI configured with appropriate credentials
+2. .NET 8+ SDK installed
+3. ECR repositories created for each service
+4. VPC with public and private subnets
+5. RDS databases (or equivalent) for data storage
+6. RabbitMQ or Amazon MQ for message queuing
+
+## Building and Publishing Containers
+
+### Using .NET SDK Container Publishing (Recommended - No Dockerfiles needed!)
+
+.NET 8+ has built-in container support. Build and push directly to ECR using CLI arguments:
+
+```bash
+# Login to ECR
+aws ecr get-login-password --region eu-west-2 | \
+  docker login --username AWS --password-stdin {account-id}.dkr.ecr.eu-west-2.amazonaws.com
+
+# Build and publish - pass container settings as CLI arguments
+dotnet publish src/API/API.csproj \
+  --configuration Release \
+  --target:PublishContainer \
+  --property:ContainerRegistry={account-id}.dkr.ecr.eu-west-2.amazonaws.com \
+  --property:ContainerRepository=preprod/api \
+  --property:ContainerImageTag=abc123
+
+dotnet publish src/Visualiser/Visualiser.csproj \
+  --configuration Release \
+  --target:PublishContainer \
+  --property:ContainerRegistry={account-id}.dkr.ecr.eu-west-2.amazonaws.com \
+  --property:ContainerRepository=prod/visualiser \
+  --property:ContainerImageTag=def456
+
+# Repeat for other services: Blocking, Cleanup, Delius.Parser, FileSync, Import, 
+# Logging, Matching.Engine, Meow, Offloc.Cleaner, Offloc.Parser
+```
+
+**Note**: 
+- Dockerfiles are not required when using SDK container publishing
+- Pass configuration via CLI args (like the CI/CD pipeline does) rather than hardcoding in .csproj
+- Use environment-specific repository names: `preprod/{service}` or `prod/{service}`
+
+## Configuration Steps
+
+### 1. Configure Secrets and Environment Variables
+
+Each service requires configuration for:
+- Database connection strings (via AWS Secrets Manager)
+- RabbitMQ connection details
+- S3 bucket names
+- Sentry DSN (optional)
+
+Add these to the `secrets` array in task definitions:
+```json
+"secrets": [
+  {
+    "name": "ConnectionStrings__ClusterDb",
+    "valueFrom": "arn:aws:secretsmanager:eu-west-2:{account-id}:secret:dms/cluster-db"
+  }
+]
+```
+
+**Note**: Container images are automatically set by the CI/CD pipeline using the `PLACEHOLDER` value. The deployment workflow dynamically injects the correct image URIs at deploy time.
+
+## Registering Task Definitions
+
+**Note**: Task definitions are automatically registered by the CI/CD pipeline during deployment.
+
+For manual registration (if needed):
+```bash
+aws ecs register-task-definition --cli-input-json file://task-definitions/api-task-def.json
+aws ecs register-task-definition --cli-input-json file://task-definitions/blocking-task-def.json
+# ... repeat for each service
+```
+
+## Create ECS Services
+
+After registering task definitions, create services:
+```bash
+aws ecs create-service \
+  --cluster dms-cluster-dev \
+  --service-name dms-api \
+  --task-definition dms-api-task \
+  --desired-count 2 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-xxxxx],securityGroups=[sg-xxxxx],assignPublicIp=DISABLED}" \
+  --load-balancers "targetGroupArn=arn:aws:elasticloadbalancing:...,containerName=api-container,containerPort=8080"
+```
+
+## Service Architecture
+
+### Public Services (behind ALB)
+- **API** - Main REST API endpoint
+- **Visualiser** - Web UI for data visualization
+
+### Internal Services (no load balancer)
+- **Blocking** - Handles blocking operations
+- **Cleanup** - Data cleanup tasks
+- **Delius Parser** - Parses Delius data files
+- **FileSync** - Syncs files to/from S3
+- **Import** - Imports data from external sources
+- **Logging** - Aggregates and processes logs
+- **Matching Engine** - Performs data matching operations
+- **Meow** - Message processing service
+- **Offloc Cleaner** - Cleans Offloc data
+- **Offloc Parser** - Parses Offloc data files
+
+## Monitoring
+
+All services log to CloudWatch Logs:
+- Log group format: `/ecs/dms-{service-name}`
+- Retention: 30 days (configurable in Terraform)
+- Container Insights enabled for metrics

--- a/infra/services.json
+++ b/infra/services.json
@@ -4,73 +4,138 @@
       "name": "api",
       "project": "API/API.csproj",
       "taskDef": "infra/task-definitions/api-task-def.json",
-      "container": "api-container"
+      "container": "api-container",
+      "secrets": [
+        "AuditDb",
+        "DeliusRunningPictureDb",
+        "OfflocRunningPictureDb",
+        "ClusterDb",
+        "Client_ID",
+        "Authentication_ApiKey",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "offloc-cleaner",
       "project": "Offloc.Cleaner/Offloc.Cleaner.csproj",
       "taskDef": "infra/task-definitions/offloc-cleaner-task-def.json",
-      "container": "offloc-cleaner-container"
+      "container": "offloc-cleaner-container",
+      "secrets": [
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "matching-engine",
       "project": "Matching.Engine/Matching.Engine.csproj",
       "taskDef": "infra/task-definitions/matching-engine-task-def.json",
-      "container": "matching-engine-container"
+      "container": "matching-engine-container",
+      "secrets": [
+        "ClusterDb",
+        "MatchingDb",
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "cleanup",
       "project": "Cleanup/Cleanup.csproj",
       "taskDef": "infra/task-definitions/cleanup-task-def.json",
-      "container": "cleanup-container"
+      "container": "cleanup-container",
+      "secrets": [
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "import",
       "project": "Import/Import.csproj",
       "taskDef": "infra/task-definitions/import-task-def.json",
-      "container": "import-container"
+      "container": "import-container",
+      "secrets": [
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "visualiser",
       "project": "Visualiser/Visualiser.csproj",
       "taskDef": "infra/task-definitions/visualiser-task-def.json",
-      "container": "visualiser-container"
+      "container": "visualiser-container",
+      "secrets": [
+        "API_Base_URL",
+        "Client_ID",
+        "Client_Secret",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "offloc-parser",
       "project": "Offloc.Parser/Offloc.Parser.csproj",
       "taskDef": "infra/task-definitions/offloc-parser-task-def.json",
-      "container": "offloc-parser-container"
+      "container": "offloc-parser-container",
+      "secrets": [
+        "OfflocStagingDb",
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "delius-parser",
       "project": "Delius.Parser/Delius.Parser.csproj",
       "taskDef": "infra/task-definitions/delius-parser-task-def.json",
-      "container": "delius-parser-container"
+      "container": "delius-parser-container",
+      "secrets": [
+        "DeliusStagingDb",
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "blocking",
       "project": "Blocking/Blocking.csproj",
       "taskDef": "infra/task-definitions/blocking-task-def.json",
-      "container": "blocking-container"
+      "container": "blocking-container",
+      "secrets": [
+        "MatchingDb",
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "logging",
       "project": "Logging/Logging.csproj",
       "taskDef": "infra/task-definitions/logging-task-def.json",
-      "container": "logging-container"
+      "container": "logging-container",
+      "secrets": [
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "filesync",
       "project": "FileSync/FileSync.csproj",
       "taskDef": "infra/task-definitions/filesync-task-def.json",
-      "container": "filesync-container"
+      "container": "filesync-container",
+      "secrets": [
+        "S3_BucketName",
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
     },
     {
       "name": "meow",
       "project": "Meow/Meow.csproj",
       "taskDef": "infra/task-definitions/meow-task-def.json",
-      "container": "meow-container"
+      "container": "meow-container",
+      "secrets": [
+        "AuditDb",
+        "DeliusRunningPictureDb",
+        "OfflocRunningPictureDb",
+        "ClusterDb",
+        "CatsRabbitMQ",
+        "Sentry_Dsn"
+      ]
     }
   ]
 }

--- a/infra/services.json
+++ b/infra/services.json
@@ -1,0 +1,76 @@
+{
+  "services": [
+    {
+      "name": "api",
+      "project": "API/API.csproj",
+      "taskDef": "infra/task-definitions/api-task-def.json",
+      "container": "api-container"
+    },
+    {
+      "name": "offloc-cleaner",
+      "project": "Offloc.Cleaner/Offloc.Cleaner.csproj",
+      "taskDef": "infra/task-definitions/offloc-cleaner-task-def.json",
+      "container": "offloc-cleaner-container"
+    },
+    {
+      "name": "matching-engine",
+      "project": "Matching.Engine/Matching.Engine.csproj",
+      "taskDef": "infra/task-definitions/matching-engine-task-def.json",
+      "container": "matching-engine-container"
+    },
+    {
+      "name": "cleanup",
+      "project": "Cleanup/Cleanup.csproj",
+      "taskDef": "infra/task-definitions/cleanup-task-def.json",
+      "container": "cleanup-container"
+    },
+    {
+      "name": "import",
+      "project": "Import/Import.csproj",
+      "taskDef": "infra/task-definitions/import-task-def.json",
+      "container": "import-container"
+    },
+    {
+      "name": "visualiser",
+      "project": "Visualiser/Visualiser.csproj",
+      "taskDef": "infra/task-definitions/visualiser-task-def.json",
+      "container": "visualiser-container"
+    },
+    {
+      "name": "offloc-parser",
+      "project": "Offloc.Parser/Offloc.Parser.csproj",
+      "taskDef": "infra/task-definitions/offloc-parser-task-def.json",
+      "container": "offloc-parser-container"
+    },
+    {
+      "name": "delius-parser",
+      "project": "Delius.Parser/Delius.Parser.csproj",
+      "taskDef": "infra/task-definitions/delius-parser-task-def.json",
+      "container": "delius-parser-container"
+    },
+    {
+      "name": "blocking",
+      "project": "Blocking/Blocking.csproj",
+      "taskDef": "infra/task-definitions/blocking-task-def.json",
+      "container": "blocking-container"
+    },
+    {
+      "name": "logging",
+      "project": "Logging/Logging.csproj",
+      "taskDef": "infra/task-definitions/logging-task-def.json",
+      "container": "logging-container"
+    },
+    {
+      "name": "filesync",
+      "project": "FileSync/FileSync.csproj",
+      "taskDef": "infra/task-definitions/filesync-task-def.json",
+      "container": "filesync-container"
+    },
+    {
+      "name": "meow",
+      "project": "Meow/Meow.csproj",
+      "taskDef": "infra/task-definitions/meow-task-def.json",
+      "container": "meow-container"
+    }
+  ]
+}

--- a/infra/services.json
+++ b/infra/services.json
@@ -21,6 +21,7 @@
       "taskDef": "infra/task-definitions/offloc-cleaner-task-def.json",
       "container": "offloc-cleaner-container",
       "secrets": [
+        "DMSFilesBasePath",
         "RabbitMQ",
         "Sentry_Dsn"
       ]
@@ -43,6 +44,7 @@
       "taskDef": "infra/task-definitions/cleanup-task-def.json",
       "container": "cleanup-container",
       "secrets": [
+        "DMSFilesBasePath",
         "RabbitMQ",
         "Sentry_Dsn"
       ]
@@ -75,6 +77,7 @@
       "taskDef": "infra/task-definitions/offloc-parser-task-def.json",
       "container": "offloc-parser-container",
       "secrets": [
+        "DMSFilesBasePath",
         "OfflocStagingDb",
         "RabbitMQ",
         "Sentry_Dsn"
@@ -86,6 +89,7 @@
       "taskDef": "infra/task-definitions/delius-parser-task-def.json",
       "container": "delius-parser-container",
       "secrets": [
+        "DMSFilesBasePath",
         "DeliusStagingDb",
         "RabbitMQ",
         "Sentry_Dsn"
@@ -97,6 +101,7 @@
       "taskDef": "infra/task-definitions/dbinteractions-task-def.json",
       "container": "dbinteractions-container",
       "secrets": [
+        "DMSFilesBasePath",
         "DeliusRunningPictureDb",
         "OfflocRunningPictureDb",
         "DeliusStagingDb",
@@ -132,6 +137,7 @@
       "taskDef": "infra/task-definitions/filesync-task-def.json",
       "container": "filesync-container",
       "secrets": [
+        "DMSFilesBasePath",
         "S3_BucketName",
         "RabbitMQ",
         "Sentry_Dsn"

--- a/infra/services.json
+++ b/infra/services.json
@@ -92,6 +92,20 @@
       ]
     },
     {
+      "name": "dbinteractions",
+      "project": "DbInteractions/DbInteractions.csproj",
+      "taskDef": "infra/task-definitions/dbinteractions-task-def.json",
+      "container": "dbinteractions-container",
+      "secrets": [
+        "DeliusRunningPictureDb",
+        "OfflocRunningPictureDb",
+        "DeliusStagingDb",
+        "OfflocStagingDb",
+        "RabbitMQ",
+        "Sentry_Dsn"
+      ]
+    },
+    {
       "name": "blocking",
       "project": "Blocking/Blocking.csproj",
       "taskDef": "infra/task-definitions/blocking-task-def.json",

--- a/infra/services.json
+++ b/infra/services.json
@@ -10,7 +10,7 @@
         "DeliusRunningPictureDb",
         "OfflocRunningPictureDb",
         "ClusterDb",
-        "Client_ID",
+        "API_Client_ID",
         "Authentication_ApiKey",
         "Sentry_Dsn"
       ]

--- a/infra/task-definitions/api-task-def.json
+++ b/infra/task-definitions/api-task-def.json
@@ -1,10 +1,10 @@
 {
     "containerDefinitions": [
         {
-            "name": "dms-visualiser-container",
+            "name": "api-container",
             "image": "PLACEHOLDER",
-            "cpu": 256,
-            "memory": 512,
+            "cpu": 512,
+            "memory": 1024,
             "portMappings": [
                 {
                     "containerPort": 8080,
@@ -21,12 +21,13 @@
             ],
             "essential": true,
             "environment": [],
+            "secrets": [],
             "mountPoints": [],
             "volumesFrom": [],
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {
-                    "awslogs-group": "ecs/dms-visualiser",
+                    "awslogs-group": "/ecs/dms-api",
                     "awslogs-region": "eu-west-2",
                     "awslogs-stream-prefix": "ecs"
                 }
@@ -34,45 +35,17 @@
             "systemControls": []
         }
     ],
-    "family": "dms-visualiser-task",
-    "taskRoleArn": "arn:aws:iam::035941410605:role/DMS-PreProd_ecs_task_role",
+    "family": "dms-api-task",
     "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
-    "revision": 6,
     "volumes": [],
-    "status": "ACTIVE",
-    "requiresAttributes": [
-        {
-            "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
-        },
-        {
-            "name": "ecs.capability.execution-role-awslogs"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.ecr-auth"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
-        },
-        {
-            "name": "ecs.capability.execution-role-ecr-pull"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
-        },
-        {
-            "name": "ecs.capability.task-eni"
-        }
-    ],
     "placementConstraints": [],
     "compatibilities": [
-        "EC2",
-        "MANAGED_INSTANCES",
         "FARGATE"
     ],
     "requiresCompatibilities": [
         "FARGATE"
     ],
-    "cpu": "256",
-    "memory": "512"
+    "cpu": "512",
+    "memory": "1024"
 }

--- a/infra/task-definitions/api-task-def.json
+++ b/infra/task-definitions/api-task-def.json
@@ -36,7 +36,6 @@
         }
     ],
     "family": "dms-api-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [],
     "placementConstraints": [],

--- a/infra/task-definitions/api-task-def.json
+++ b/infra/task-definitions/api-task-def.json
@@ -27,9 +27,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-api",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/api"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/api-task-def.json
+++ b/infra/task-definitions/api-task-def.json
@@ -1,50 +1,50 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "api-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "portMappings": [
         {
-            "name": "api-container",
-            "image": "PLACEHOLDER",
-            "cpu": 512,
-            "memory": 1024,
-            "portMappings": [
-                {
-                    "containerPort": 8080,
-                    "hostPort": 8080,
-                    "protocol": "tcp",
-                    "name": "http"
-                },
-                {
-                    "containerPort": 8081,
-                    "hostPort": 8081,
-                    "protocol": "tcp",
-                    "name": "https"
-                }
-            ],
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-api",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "name": "http"
+        },
+        {
+          "containerPort": 8081,
+          "hostPort": 8081,
+          "protocol": "tcp",
+          "name": "https"
         }
-    ],
-    "family": "dms-api-task",
-    "networkMode": "awsvpc",
-    "volumes": [],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "512",
-    "memory": "1024"
+      ],
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-api",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "PLACEHOLDER",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
 }

--- a/infra/task-definitions/blocking-task-def.json
+++ b/infra/task-definitions/blocking-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "blocking-container",
+            "image": "PLACEHOLDER",
+            "cpu": 512,
+            "memory": 1024,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-blocking",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-blocking-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "512",
+    "memory": "1024"
+}

--- a/infra/task-definitions/blocking-task-def.json
+++ b/infra/task-definitions/blocking-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "blocking-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "blocking-container",
-            "image": "PLACEHOLDER",
-            "cpu": 512,
-            "memory": 1024,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-blocking",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-blocking-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-blocking",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "512",
-    "memory": "1024"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-blocking-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
 }

--- a/infra/task-definitions/blocking-task-def.json
+++ b/infra/task-definitions/blocking-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-blocking-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/blocking-task-def.json
+++ b/infra/task-definitions/blocking-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-blocking",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/blocking"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/blocking-task-def.json
+++ b/infra/task-definitions/blocking-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-blocking-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/cleanup-task-def.json
+++ b/infra/task-definitions/cleanup-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "cleanup-container",
+      "image": "PLACEHOLDER",
+      "cpu": 256,
+      "memory": 512,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "cleanup-container",
-            "image": "PLACEHOLDER",
-            "cpu": 256,
-            "memory": 512,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-cleanup",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-cleanup-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-cleanup",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "256",
-    "memory": "512"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-cleanup-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512"
 }

--- a/infra/task-definitions/cleanup-task-def.json
+++ b/infra/task-definitions/cleanup-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-cleanup-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/cleanup-task-def.json
+++ b/infra/task-definitions/cleanup-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "cleanup-container",
+            "image": "PLACEHOLDER",
+            "cpu": 256,
+            "memory": 512,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-cleanup",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-cleanup-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "256",
+    "memory": "512"
+}

--- a/infra/task-definitions/cleanup-task-def.json
+++ b/infra/task-definitions/cleanup-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-cleanup-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/cleanup-task-def.json
+++ b/infra/task-definitions/cleanup-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-cleanup",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/cleanup"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/dbinteractions-task-def.json
+++ b/infra/task-definitions/dbinteractions-task-def.json
@@ -1,0 +1,53 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "dbinteractions-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
+        {
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
+        }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-dbinteractions",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-dbinteractions-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
+}

--- a/infra/task-definitions/dbinteractions-task-def.json
+++ b/infra/task-definitions/dbinteractions-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-dbinteractions",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/dbinteractions"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/dbinteractions-task-def.json
+++ b/infra/task-definitions/dbinteractions-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-dbinteractions-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/delius-parser-task-def.json
+++ b/infra/task-definitions/delius-parser-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-delius-parser-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/delius-parser-task-def.json
+++ b/infra/task-definitions/delius-parser-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "delius-parser-container",
+            "image": "PLACEHOLDER",
+            "cpu": 512,
+            "memory": 1024,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-delius-parser",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-delius-parser-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "512",
+    "memory": "1024"
+}

--- a/infra/task-definitions/delius-parser-task-def.json
+++ b/infra/task-definitions/delius-parser-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "delius-parser-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "delius-parser-container",
-            "image": "PLACEHOLDER",
-            "cpu": 512,
-            "memory": 1024,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-delius-parser",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-delius-parser-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-delius-parser",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "512",
-    "memory": "1024"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-delius-parser-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
 }

--- a/infra/task-definitions/delius-parser-task-def.json
+++ b/infra/task-definitions/delius-parser-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-delius-parser-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/delius-parser-task-def.json
+++ b/infra/task-definitions/delius-parser-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-delius-parser",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/delius-parser"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/filesync-task-def.json
+++ b/infra/task-definitions/filesync-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "filesync-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "filesync-container",
-            "image": "PLACEHOLDER",
-            "cpu": 512,
-            "memory": 1024,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-filesync",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-filesync-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-filesync",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "512",
-    "memory": "1024"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-filesync-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
 }

--- a/infra/task-definitions/filesync-task-def.json
+++ b/infra/task-definitions/filesync-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "filesync-container",
+            "image": "PLACEHOLDER",
+            "cpu": 512,
+            "memory": 1024,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-filesync",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-filesync-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "512",
+    "memory": "1024"
+}

--- a/infra/task-definitions/filesync-task-def.json
+++ b/infra/task-definitions/filesync-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-filesync-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/filesync-task-def.json
+++ b/infra/task-definitions/filesync-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-filesync",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/filesync"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/filesync-task-def.json
+++ b/infra/task-definitions/filesync-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-filesync-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/import-task-def.json
+++ b/infra/task-definitions/import-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "import-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "import-container",
-            "image": "PLACEHOLDER",
-            "cpu": 512,
-            "memory": 1024,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-import",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-import-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-import",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "512",
-    "memory": "1024"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-import-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
 }

--- a/infra/task-definitions/import-task-def.json
+++ b/infra/task-definitions/import-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "import-container",
+            "image": "PLACEHOLDER",
+            "cpu": 512,
+            "memory": 1024,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-import",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-import-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "512",
+    "memory": "1024"
+}

--- a/infra/task-definitions/import-task-def.json
+++ b/infra/task-definitions/import-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-import-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/import-task-def.json
+++ b/infra/task-definitions/import-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-import-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/import-task-def.json
+++ b/infra/task-definitions/import-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-import",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/import"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/logging-task-def.json
+++ b/infra/task-definitions/logging-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "logging-container",
+      "image": "PLACEHOLDER",
+      "cpu": 256,
+      "memory": 512,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "logging-container",
-            "image": "PLACEHOLDER",
-            "cpu": 256,
-            "memory": 512,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-logging",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-logging-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-logging",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "256",
-    "memory": "512"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-logging-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512"
 }

--- a/infra/task-definitions/logging-task-def.json
+++ b/infra/task-definitions/logging-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "logging-container",
+            "image": "PLACEHOLDER",
+            "cpu": 256,
+            "memory": 512,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-logging",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-logging-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "256",
+    "memory": "512"
+}

--- a/infra/task-definitions/logging-task-def.json
+++ b/infra/task-definitions/logging-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-logging-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/logging-task-def.json
+++ b/infra/task-definitions/logging-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-logging",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/logging"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/logging-task-def.json
+++ b/infra/task-definitions/logging-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-logging-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/matching-engine-task-def.json
+++ b/infra/task-definitions/matching-engine-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "matching-engine-container",
+      "image": "PLACEHOLDER",
+      "cpu": 1024,
+      "memory": 2048,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "matching-engine-container",
-            "image": "PLACEHOLDER",
-            "cpu": 1024,
-            "memory": 2048,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-matching-engine",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-matching-engine-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-matching-engine",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "1024",
-    "memory": "2048"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-matching-engine-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "1024",
+  "memory": "2048"
 }

--- a/infra/task-definitions/matching-engine-task-def.json
+++ b/infra/task-definitions/matching-engine-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "matching-engine-container",
+            "image": "PLACEHOLDER",
+            "cpu": 1024,
+            "memory": 2048,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-matching-engine",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-matching-engine-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "1024",
+    "memory": "2048"
+}

--- a/infra/task-definitions/matching-engine-task-def.json
+++ b/infra/task-definitions/matching-engine-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-matching-engine-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/matching-engine-task-def.json
+++ b/infra/task-definitions/matching-engine-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-matching-engine",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/matching-engine"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/matching-engine-task-def.json
+++ b/infra/task-definitions/matching-engine-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-matching-engine-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/meow-task-def.json
+++ b/infra/task-definitions/meow-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-meow-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/meow-task-def.json
+++ b/infra/task-definitions/meow-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "meow-container",
+            "image": "PLACEHOLDER",
+            "cpu": 512,
+            "memory": 1024,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-meow",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-meow-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "512",
+    "memory": "1024"
+}

--- a/infra/task-definitions/meow-task-def.json
+++ b/infra/task-definitions/meow-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "meow-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "meow-container",
-            "image": "PLACEHOLDER",
-            "cpu": 512,
-            "memory": 1024,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-meow",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-meow-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-meow",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "512",
-    "memory": "1024"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-meow-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
 }

--- a/infra/task-definitions/meow-task-def.json
+++ b/infra/task-definitions/meow-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-meow",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/meow"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/meow-task-def.json
+++ b/infra/task-definitions/meow-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-meow-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/offloc-cleaner-task-def.json
+++ b/infra/task-definitions/offloc-cleaner-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "offloc-cleaner-container",
+            "image": "PLACEHOLDER",
+            "cpu": 512,
+            "memory": 1024,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-offloc-cleaner",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-offloc-cleaner-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "512",
+    "memory": "1024"
+}

--- a/infra/task-definitions/offloc-cleaner-task-def.json
+++ b/infra/task-definitions/offloc-cleaner-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-offloc-cleaner-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/offloc-cleaner-task-def.json
+++ b/infra/task-definitions/offloc-cleaner-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "offloc-cleaner-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "offloc-cleaner-container",
-            "image": "PLACEHOLDER",
-            "cpu": 512,
-            "memory": 1024,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-offloc-cleaner",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-offloc-cleaner-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-offloc-cleaner",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "512",
-    "memory": "1024"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-offloc-cleaner-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
 }

--- a/infra/task-definitions/offloc-cleaner-task-def.json
+++ b/infra/task-definitions/offloc-cleaner-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-offloc-cleaner-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/offloc-cleaner-task-def.json
+++ b/infra/task-definitions/offloc-cleaner-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-offloc-cleaner",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/offloc-cleaner"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/offloc-parser-task-def.json
+++ b/infra/task-definitions/offloc-parser-task-def.json
@@ -28,7 +28,6 @@
         }
     ],
     "family": "dms-offloc-parser-task",
-    "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [
         {

--- a/infra/task-definitions/offloc-parser-task-def.json
+++ b/infra/task-definitions/offloc-parser-task-def.json
@@ -1,50 +1,53 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "offloc-parser-container",
+      "image": "PLACEHOLDER",
+      "cpu": 512,
+      "memory": 1024,
+      "essential": true,
+      "environment": [],
+      "secrets": [],
+      "mountPoints": [
         {
-            "name": "offloc-parser-container",
-            "image": "PLACEHOLDER",
-            "cpu": 512,
-            "memory": 1024,
-            "essential": true,
-            "environment": [],
-            "secrets": [],
-            "mountPoints": [
-                {
-                    "sourceVolume": "dms-efs",
-                    "containerPath": "/mnt/efs",
-                    "readOnly": false
-                }
-            ],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/dms-offloc-parser",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "sourceVolume": "dms-efs",
+          "containerPath": "/mnt/efs",
+          "readOnly": false
         }
-    ],
-    "family": "dms-offloc-parser-task",
-    "networkMode": "awsvpc",
-    "volumes": [
-        {
-            "name": "dms-efs",
-            "efsVolumeConfiguration": {
-                "fileSystemId": "EFS_FILE_SYSTEM_ID",
-                "transitEncryption": "ENABLED"
-            }
+      ],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dms-offloc-parser",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "512",
-    "memory": "1024"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "dms-offloc-parser-task",
+  "networkMode": "awsvpc",
+  "volumes": [
+    {
+      "name": "dms-efs",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "EFS_FILE_SYSTEM_ID",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "accessPointId": "EFS_ACCESS_POINT_ID"
+        }
+      }
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "512",
+  "memory": "1024"
 }

--- a/infra/task-definitions/offloc-parser-task-def.json
+++ b/infra/task-definitions/offloc-parser-task-def.json
@@ -1,0 +1,51 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "offloc-parser-container",
+            "image": "PLACEHOLDER",
+            "cpu": 512,
+            "memory": 1024,
+            "essential": true,
+            "environment": [],
+            "secrets": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dms-efs",
+                    "containerPath": "/mnt/efs",
+                    "readOnly": false
+                }
+            ],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/dms-offloc-parser",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-offloc-parser-task",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [
+        {
+            "name": "dms-efs",
+            "efsVolumeConfiguration": {
+                "fileSystemId": "EFS_FILE_SYSTEM_ID",
+                "transitEncryption": "ENABLED"
+            }
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "512",
+    "memory": "1024"
+}

--- a/infra/task-definitions/offloc-parser-task-def.json
+++ b/infra/task-definitions/offloc-parser-task-def.json
@@ -19,9 +19,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/dms-offloc-parser",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/offloc-parser"
         }
       },
       "systemControls": []

--- a/infra/task-definitions/offloc-parser-task-def.json
+++ b/infra/task-definitions/offloc-parser-task-def.json
@@ -27,7 +27,7 @@
       "systemControls": []
     }
   ],
-  "family": "dms-offloc-parser-task",
+  "family": "PLACEHOLDER",
   "networkMode": "awsvpc",
   "volumes": [
     {

--- a/infra/task-definitions/visualiser-task-def.json
+++ b/infra/task-definitions/visualiser-task-def.json
@@ -34,9 +34,7 @@
             "systemControls": []
         }
     ],
-    "family": "dms-visualiser-task",
-    "taskRoleArn": "arn:aws:iam::035941410605:role/DMS-PreProd_ecs_task_role",
-    "executionRoleArn": "ecsTaskExecutionRole",
+    "family": "visualiser-task",
     "networkMode": "awsvpc",
     "revision": 6,
     "volumes": [],

--- a/infra/task-definitions/visualiser-task-def.json
+++ b/infra/task-definitions/visualiser-task-def.json
@@ -1,0 +1,78 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "visualiser-container",
+            "image": "PLACEHOLDER",
+            "cpu": 256,
+            "memory": 512,
+            "portMappings": [
+                {
+                    "containerPort": 8080,
+                    "hostPort": 8080,
+                    "protocol": "tcp",
+                    "name": "http"
+                },
+                {
+                    "containerPort": 8081,
+                    "hostPort": 8081,
+                    "protocol": "tcp",
+                    "name": "https"
+                }
+            ],
+            "essential": true,
+            "environment": [],
+            "mountPoints": [],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "ecs/visualiser",
+                    "awslogs-region": "eu-west-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "dms-visualiser-task",
+    "taskRoleArn": "arn:aws:iam::035941410605:role/DMS-PreProd_ecs_task_role",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "revision": 6,
+    "volumes": [],
+    "status": "ACTIVE",
+    "requiresAttributes": [
+        {
+            "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+        },
+        {
+            "name": "ecs.capability.execution-role-awslogs"
+        },
+        {
+            "name": "com.amazonaws.ecs.capability.ecr-auth"
+        },
+        {
+            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+        },
+        {
+            "name": "ecs.capability.execution-role-ecr-pull"
+        },
+        {
+            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+        },
+        {
+            "name": "ecs.capability.task-eni"
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "EC2",
+        "MANAGED_INSTANCES",
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "256",
+    "memory": "512"
+}

--- a/infra/task-definitions/visualiser-task-def.json
+++ b/infra/task-definitions/visualiser-task-def.json
@@ -1,76 +1,76 @@
 {
-    "containerDefinitions": [
+  "containerDefinitions": [
+    {
+      "name": "visualiser-container",
+      "image": "PLACEHOLDER",
+      "cpu": 256,
+      "memory": 512,
+      "portMappings": [
         {
-            "name": "visualiser-container",
-            "image": "PLACEHOLDER",
-            "cpu": 256,
-            "memory": 512,
-            "portMappings": [
-                {
-                    "containerPort": 8080,
-                    "hostPort": 8080,
-                    "protocol": "tcp",
-                    "name": "http"
-                },
-                {
-                    "containerPort": 8081,
-                    "hostPort": 8081,
-                    "protocol": "tcp",
-                    "name": "https"
-                }
-            ],
-            "essential": true,
-            "environment": [],
-            "mountPoints": [],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "ecs/visualiser",
-                    "awslogs-region": "eu-west-2",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            },
-            "systemControls": []
+          "containerPort": 8080,
+          "hostPort": 8080,
+          "protocol": "tcp",
+          "name": "http"
+        },
+        {
+          "containerPort": 8081,
+          "hostPort": 8081,
+          "protocol": "tcp",
+          "name": "https"
         }
-    ],
-    "family": "visualiser-task",
-    "networkMode": "awsvpc",
-    "revision": 6,
-    "volumes": [],
-    "status": "ACTIVE",
-    "requiresAttributes": [
-        {
-            "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
-        },
-        {
-            "name": "ecs.capability.execution-role-awslogs"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.ecr-auth"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
-        },
-        {
-            "name": "ecs.capability.execution-role-ecr-pull"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
-        },
-        {
-            "name": "ecs.capability.task-eni"
+      ],
+      "essential": true,
+      "environment": [],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "ecs/visualiser",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "ecs"
         }
-    ],
-    "placementConstraints": [],
-    "compatibilities": [
-        "EC2",
-        "MANAGED_INSTANCES",
-        "FARGATE"
-    ],
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "cpu": "256",
-    "memory": "512"
+      },
+      "systemControls": []
+    }
+  ],
+  "family": "PLACEHOLDER",
+  "networkMode": "awsvpc",
+  "revision": 6,
+  "volumes": [],
+  "status": "ACTIVE",
+  "requiresAttributes": [
+    {
+      "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+    },
+    {
+      "name": "ecs.capability.execution-role-awslogs"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.ecr-auth"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+    },
+    {
+      "name": "ecs.capability.execution-role-ecr-pull"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+    },
+    {
+      "name": "ecs.capability.task-eni"
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "EC2",
+    "MANAGED_INSTANCES",
+    "FARGATE"
+  ],
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512"
 }

--- a/infra/task-definitions/visualiser-task-def.json
+++ b/infra/task-definitions/visualiser-task-def.json
@@ -26,9 +26,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "ecs/visualiser",
+          "awslogs-group": "PLACEHOLDER",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "ecs"
+          "awslogs-stream-prefix": "ecs/visualiser"
         }
       },
       "systemControls": []

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -14,6 +14,8 @@ builder.UseDmsSerilog();
 
 // Add service defaults & Aspire components.
 builder.AddServiceDefaults();
+builder.Services.AddRequestTimeouts();
+builder.Services.AddOutputCache();
 
 builder.Services.AddOpenApiDocument(options =>
 {
@@ -119,6 +121,9 @@ if (builder.Configuration["IsDevelopment"] is not null && builder.Configuration.
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.UseRequestTimeouts();
+app.UseOutputCache();
 
 app.RegisterClusteringEndpoints()
    .RegisterDeliusEndpoints()

--- a/src/Database/OfflocStagingDb/Stored Procedures/Import.sql
+++ b/src/Database/OfflocStagingDb/Stored Procedures/Import.sql
@@ -2,75 +2,23 @@
 -- Author:		Daniel Fenelon
 -- Create date: 18/03/2024
 -- Description:	Import of the OffLoc files
+-- Note:        File loading removed - data is now staged via SqlBulkCopy
+--              in the DbInteractions service. This procedure handles
+--              post-load standardisation and status update only.
 -- =============================================
 
 CREATE PROCEDURE [OfflocStaging].[Import]
-    @basePath VARCHAR(100),
     @processedFile VARCHAR(50)
 AS
 BEGIN
 
     SET NOCOUNT ON;
     SET DATEFORMAT DMY;
-    
-    CREATE TABLE #TableNames
-    (
-        Id INT PRIMARY KEY IDENTITY,
-        fileName VARCHAR(50) NOT NULL
-    );
-    INSERT INTO #TableNames
-    (
-        fileName
-    )
-    VALUES
-    ('Activities'),
-    ('Addresses'),
-    ('Agencies'),
-    ('Assessments'),
-    ('Bookings'),
-    ('Employment'),
-    ('Flags'),
-    ('Identifiers'),
-    ('IncentiveLevel'),
-    ('Locations'),
-    ('MainOffence'),
-    ('Movements'),
-    ('OffenderAgencies'),
-    ('OffenderStatus'),
-    ('OtherOffences'),
-    ('PersonalDetails'),
-    ('PNC'),
-    ('PreviousPrisonNumbers'),
-    ('SentenceInformation'),
-    ('SexOffenders');
-
-    DECLARE @i INT;
-    DECLARE @sql VARCHAR(250);
-    DECLARE @fileName VARCHAR(150);
-
-    SET @i = 1;
 
     BEGIN TRANSACTION;
     BEGIN TRY
-        WHILE @i <= (SELECT COUNT(*)FROM #TableNames)
-        BEGIN
-            SET @fileName =
-            (
-                SELECT fileName FROM #TableNames WHERE Id = @i
-            );
-            SET @sql
-                = N'BULK INSERT OfflocStaging.' + @fileName + N' FROM ''' + @basePath + @fileName + '.txt'''
-                  + N' WITH (FieldTerminator = ''|'', RowTerminator = ''0x0d0a'', MAXERRORS = 1000)';
-            EXEC (@sql);
-
-            SET @i = @i + 1;
-        END;
-        DECLARE @stringDate CHAR(8);
-        SET @stringDate = SUBSTRING(@processedFile, 18, 8);
-
-        --Standardise Offloc Data
-        Declare @retMessage varchar(500);
-        EXEC [OfflocStaging].[StandardiseData] @retMessage;
+        DECLARE @retMessage VARCHAR(500);
+        EXEC [OfflocStaging].[StandardiseData] @retMessage OUTPUT;
 
         UPDATE [OfflocRunningPictureDb].[OfflocRunningPicture].[ProcessedFiles]
         SET [Status] = 'Imported'

--- a/src/DbInteractions/Services/DbInteractionService.cs
+++ b/src/DbInteractions/Services/DbInteractionService.cs
@@ -192,21 +192,48 @@ public class DbInteractionService : IDbInteractionService
     public async Task StageOffloc(string fileName)
     {
         string folderName = fileName.Split('.').First();
+        string folderPath = Path.Combine(fileLocations.offlocOutput, folderName);
+
         await messageService.PublishAsync(new StatusUpdateMessage($"Offloc staging started for file {fileName}."));
+
+        var tableNames = new[]
+        {
+            "Activities", "Addresses", "Agencies", "Assessments", "Bookings",
+            "Employment", "Flags", "Identifiers", "IncentiveLevel", "Locations",
+            "MainOffence", "Movements", "OffenderAgencies", "OffenderStatus",
+            "OtherOffences", "PersonalDetails", "PNC", "PreviousPrisonNumbers",
+            "SentenceInformation", "SexOffenders"
+        };
 
         var offlocConn = new SqlConnection(configuration.GetConnectionString("OfflocStagingDb")!);
         using (offlocConn)
         {
             await offlocConn.OpenAsync();
-            SqlCommand command = new SqlCommand(serverConfig.OfflocStagingProcedure, offlocConn);
-            command.CommandTimeout = 600;
-            command.CommandType = CommandType.StoredProcedure;
-            command.Parameters.AddWithValue("@basePath", $"{fileLocations.offlocOutput}/{folderName}/");
-            command.Parameters.AddWithValue("@processedFile", fileName);
 
             try
             {
-                var result = await command.ExecuteNonQueryAsync();
+                foreach (var table in tableNames)
+                {
+                    var filePath = Path.Combine(folderPath, $"{table}.txt");
+                    if (!File.Exists(filePath)) continue;
+
+                    var columns = await GetTableColumns(offlocConn, "OfflocStaging", table);
+                    var dataTable = ReadPipeDelimitedFile(filePath, columns);
+
+                    using var bulkCopy = new SqlBulkCopy(offlocConn)
+                    {
+                        DestinationTableName = $"[OfflocStaging].[{table}]",
+                        BulkCopyTimeout = 600
+                    };
+                    await bulkCopy.WriteToServerAsync(dataTable);
+                }
+
+                // Calls StandardiseData + updates ProcessedFiles
+                SqlCommand command = new SqlCommand(serverConfig.OfflocStagingProcedure, offlocConn);
+                command.CommandTimeout = 600;
+                command.CommandType = CommandType.StoredProcedure;
+                command.Parameters.AddWithValue("@processedFile", fileName);
+                await command.ExecuteNonQueryAsync();
             }
             catch (Exception e)
             {
@@ -215,7 +242,39 @@ public class DbInteractionService : IDbInteractionService
             }
         }
 
-        await messageService.PublishAsync(new StatusUpdateMessage($"Offloc staging finished for file {fileName}."));
+        await messageService.PublishAsync(new StatusUpdateMessage($"Offloc Staging completed."));
+    }
+
+    private async Task<List<string>> GetTableColumns(SqlConnection conn, string schema, string table)
+    {
+        var columns = new List<string>();
+        using var cmd = new SqlCommand(
+            "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = @schema AND TABLE_NAME = @table ORDER BY ORDINAL_POSITION",
+            conn);
+        cmd.Parameters.AddWithValue("@schema", schema);
+        cmd.Parameters.AddWithValue("@table", table);
+        using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            columns.Add(reader.GetString(0));
+        return columns;
+    }
+
+    private DataTable ReadPipeDelimitedFile(string filePath, List<string> columns)
+    {
+        var dataTable = new DataTable();
+        foreach (var col in columns)
+            dataTable.Columns.Add(col, typeof(string));
+
+        foreach (var line in File.ReadLines(filePath))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            var values = line.Split('|');
+            var row = dataTable.NewRow();
+            for (int i = 0; i < Math.Min(values.Length, columns.Count); i++)
+                row[i] = values[i];
+            dataTable.Rows.Add(row);
+        }
+        return dataTable;
     }
     //Calls merge and then on completion
     public async Task StandardiseDeliusStaging()

--- a/src/FileSync/appsettings.json
+++ b/src/FileSync/appsettings.json
@@ -23,7 +23,7 @@
       "Enrich": ["FromLogContext", "WithMachineName", "WithProcessId", "WithThreadId"]
     },
     "SyncOptions": {
-        "ProcessOnStartup": false,
+        "ProcessOnStartup": true,
         "ProcessOnCompletion": true,
         "ProcessOnTimer": true,
         "ProcessTimerIntervalSeconds": 900,

--- a/src/FileSync/appsettings.json
+++ b/src/FileSync/appsettings.json
@@ -24,8 +24,8 @@
     },
     "SyncOptions": {
         "ProcessOnStartup": false,
-        "ProcessOnCompletion": false,
-        "ProcessOnTimer": false,
+        "ProcessOnCompletion": true,
+        "ProcessOnTimer": true,
         "ProcessTimerIntervalSeconds": 900,
         "AllowProcessingOlderFiles": false
     },

--- a/src/FileSync/appsettings.json
+++ b/src/FileSync/appsettings.json
@@ -24,8 +24,8 @@
     },
     "SyncOptions": {
         "ProcessOnStartup": false,
-        "ProcessOnCompletion": true,
-        "ProcessOnTimer": true,
+        "ProcessOnCompletion": false,
+        "ProcessOnTimer": false,
         "ProcessTimerIntervalSeconds": 900,
         "AllowProcessingOlderFiles": false
     },

--- a/src/Libraries/EnvironmentSetup/FileLocations.cs
+++ b/src/Libraries/EnvironmentSetup/FileLocations.cs
@@ -18,6 +18,11 @@ public class FileLocations : IFileLocations
     public FileLocations(string basePath)
     {
         this._basePath = basePath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+
+        Directory.CreateDirectory(deliusInput);
+        Directory.CreateDirectory(deliusOutput);
+        Directory.CreateDirectory(offlocInput);
+        Directory.CreateDirectory(offlocOutput);
     }
     
     public string basePath { get => _basePath; }

--- a/src/Visualiser/Program.cs
+++ b/src/Visualiser/Program.cs
@@ -8,7 +8,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.UseDmsSerilog();
 
-builder.Services.AddHealthChecks();
+builder.AddServiceDefaults();
+builder.Services.AddRequestTimeouts();
+builder.Services.AddOutputCache();
 
 builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
     .AddMicrosoftIdentityWebApp(builder.Configuration)
@@ -51,14 +53,17 @@ app.UseHttpsRedirection();
 
 app.UseRouting();
 
-app.MapHealthChecks("/healthz").AllowAnonymous();
-
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.UseRequestTimeouts();
+app.UseOutputCache();
 
 app.MapStaticAssets();
 app.MapRazorPages()
    .WithStaticAssets();
+
 app.MapControllers();
+app.MapDefaultEndpoints();
 
 app.Run();

--- a/src/Visualiser/Visualiser.csproj
+++ b/src/Visualiser/Visualiser.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Aspire\Aspire.ServiceDefaults\Aspire.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Libraries\EnvironmentSetup\EnvironmentSetup.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Actions workflow for ECS deployments, restructures deployment automation to use this workflow, and updates documentation and configuration to support multi-service deployments. It also pins all GitHub Actions to specific commit SHAs for improved security and reliability.

**Key changes include:**

### CI/CD Workflow Improvements

* **Introduced a reusable deployment workflow:** Added `.github/workflows/deploy-reusable.yml` to enable parameterized, multi-service ECS deployments via matrix strategy, supporting both `preprod` and `prod` environments. This workflow dynamically loads service definitions, builds, tests, injects secrets, and deploys each service.
* **Refactored main deployment workflow:** Updated `.github/workflows/deploy.yml` to delegate deployments to the new reusable workflow, splitting deployments into `deploy-preprod` (for `develop` branch) and `deploy-prod` (for `main` branch). This replaces the previous single-job, hardcoded deployment logic.

### Security and Consistency

* **Pinned GitHub Actions to commit SHAs:** Updated all workflow files (`build-artifacts.yml`, `run-tests.yml`, `deploy-reusable.yml`) to use specific commit SHAs for all third-party actions, reducing the risk of supply chain attacks and ensuring consistent CI/CD runs. [[1]](diffhunk://#diff-b42f740b4418aaeb96e2db7ca7816039f8cfb34d8e1e4a4b7519d540b34a2a08L15-R18) [[2]](diffhunk://#diff-b42f740b4418aaeb96e2db7ca7816039f8cfb34d8e1e4a4b7519d540b34a2a08L32-R32) [[3]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L14-R14) [[4]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L37-R40) [[5]](diffhunk://#diff-9cf7c2a0c4f80876dec2934f8b0daeb9e9d0abd5bfa7cb1cf98046f943502a94R1-R241)

### Infrastructure and Documentation

* **Added infrastructure documentation:** Created `infra/README.md` with detailed instructions and architecture for managing ECS task definitions, service mappings, container publishing, and deployment via the new pipeline.
* **Removed legacy task definition:** Deleted `infra/dms-visualiser-task-def.json` as task definitions are now managed and injected dynamically by the CI/CD pipeline.

These changes collectively modernize and secure the deployment process, provide clear documentation for future contributors, and enable scalable, automated multi-service deployments.