### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,27 @@
 version: 2
+
 updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
       time: "04:00"
+    cooldown:
+      default-days: 7
+
     target-branch: "develop"
+
     commit-message:
       prefix: "deps"
+
     open-pull-requests-limit: 1
+
+    ignore:
+      - dependency-name: "AutoMapper"
+      - dependency-name: "AutoMapper.*"
+      - dependency-name: "MediatR"
+      - dependency-name: "MediatR.*"
+
     groups:
       all-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,12 +16,6 @@ updates:
 
     open-pull-requests-limit: 1
 
-    ignore:
-      - dependency-name: "AutoMapper"
-      - dependency-name: "AutoMapper.*"
-      - dependency-name: "MediatR"
-      - dependency-name: "MediatR.*"
-
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
This pull request updates the Dependabot configuration to improve dependency update management. The most significant changes are increasing the update frequency, adding cooldowns, and excluding specific dependencies from automatic updates.

Dependabot configuration updates:

* Changed the update schedule for the `nuget` ecosystem from weekly on Sundays to daily at 04:00 to ensure more frequent updates.
* Added a cooldown period of 7 days between updates to help manage update frequency and avoid excessive pull requests.
* Introduced an ignore list for dependencies matching `AutoMapper`, `AutoMapper.*`, `MediatR`, and `MediatR.*` to prevent automatic updates for these packages.